### PR TITLE
OpenAPI-Dokumentation hinzugefügt:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <!-- API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.14</version>
+        </dependency>
+
         <!-- zum laden der .env in der application properties -->
         <dependency>
             <groupId>me.paulschwarz</groupId>

--- a/src/main/java/com/spotifywrapped/spotify_wrapped_clone/service/OpenApiConfig.java
+++ b/src/main/java/com/spotifywrapped/spotify_wrapped_clone/service/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package com.spotifywrapped.spotify_wrapped_clone.service;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Spotify Wrapped Clone API",
+                version = "v1",
+                description = "OpenAPI documentation for the Spotify Wrapped Clone backend"
+        )
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/spotifywrapped/spotify_wrapped_clone/service/SecurityConfig.java
+++ b/src/main/java/com/spotifywrapped/spotify_wrapped_clone/service/SecurityConfig.java
@@ -21,7 +21,12 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers(
+                                "/api/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
                         .anyRequest().permitAll()
                 );
 


### PR DESCRIPTION
- Abhängigkeit `springdoc-openapi-starter-webmvc-ui` in `pom.xml` integriert.
- `OpenApiConfig`-Klasse für API-Dokumentation konfiguriert.
- Sicherheitskonfiguration aktualisiert, um Zugriff auf Swagger-UI und API-Dokumentation zu erlauben.

refs: #12